### PR TITLE
Add real-time clock display to calculator keypad

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,8 @@
 
   <div class="key digit zero">0</div>
   <div class="key digit">.</div>
+
+  <div class="key time-display" id="clock"></div>
 </div>
 
 </div>

--- a/main.js
+++ b/main.js
@@ -1,6 +1,14 @@
 // main.js
 (() => {
   const display = document.getElementById("display");
+  const clockDisplay = document.getElementById("clock");
+  const clockFormatter = clockDisplay
+    ? new Intl.DateTimeFormat(undefined, {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      })
+    : null;
   const keys = document.querySelector(".keys");
 
   let current = "0";
@@ -23,6 +31,14 @@
 
   function updateDisplay(value = current) {
     display.textContent = format(value);
+  }
+
+  function updateClock() {
+    if (!clockDisplay) return;
+    const now = new Date();
+    clockDisplay.textContent = clockFormatter
+      ? clockFormatter.format(now)
+      : now.toLocaleTimeString();
   }
 
   function clearAll() {
@@ -142,6 +158,7 @@
   keys.addEventListener("pointerdown", (e) => {
     const key = e.target.closest(".key");
     if (!key) return;
+    if (key.classList.contains("time-display")) return;
     // ant touch – neleisti generuoti papildomo mouse įvykio
     if (e.pointerType === "touch") e.preventDefault();
     activeKey = key;
@@ -151,6 +168,7 @@
   keys.addEventListener("pointerup", (e) => {
     const key = e.target.closest(".key");
     if (!key) return;
+    if (key.classList.contains("time-display")) return;
     if (e.pointerType === "touch") e.preventDefault();
 
     // jei paleidom kitur nei paspaudėm – vis tiek vykdom to, ant kurio paleista
@@ -227,4 +245,6 @@
 
   // Start
   updateDisplay();
+  updateClock();
+  setInterval(updateClock, 1000);
 })();

--- a/style.css
+++ b/style.css
@@ -166,6 +166,22 @@ body{
   grid-column: span 2;
 }
 
+.key.time-display {
+  grid-column: span 4;
+  justify-content: flex-end;
+  padding: 0 16px;
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: default;
+  background: var(--screen-bg);
+  color: var(--text-strong);
+  box-shadow: var(--shadow-inner), 0 1px 0 #fff inset;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  pointer-events: none;
+}
+
 #clear{
   background: linear-gradient(180deg, hsl(350 80% 90%), #fff);
   box-shadow: 0 8px 16px -6px rgb(255 90 120 / .25);


### PR DESCRIPTION
## Summary
- add a dedicated clock display row beneath the keypad
- style the time display to match the calculator screen aesthetic
- update the script to refresh the clock every second and ignore keypad interactions on it

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e4a79c25c0832e9dcd61be23f39789